### PR TITLE
fix: Fix a typo in the German translation

### DIFF
--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -25,7 +25,7 @@
     <string name="dialog_enter_device_id_qrcode">QR-Code</string>
     <string name="dialog_enter_device_id_variants">Varianten</string>
     <string name="dialog_enter_device_id_save">Speichern</string>
-    <string name="dialog_enter_device_id_exit">Beendene</string>
+    <string name="dialog_enter_device_id_exit">Beenden</string>
     <string name="dialog_enter_device_id_title">Geben Sie die Geräte-ID unter %s ein</string>
     <string name="main_start_preparations">Vorbereiten des Starts</string>
     <string name="main_downloading_configuration">Aktualisieren der Konfigurationsdatei</string>


### PR DESCRIPTION
"Beendene" is not a real word