### PR TITLE
[Handle] locked_boot_receiver mode

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -123,7 +123,8 @@
         android:theme="@style/AppTheme"
         android:name=".App"
         android:hardwareAccelerated="true"
-        tools:ignore="GoogleAppIndexingWarning">
+        tools:ignore="GoogleAppIndexingWarning"
+        android:directBootAware="true">
 
         <activity
             android:name=".ui.MainActivity"
@@ -198,7 +199,16 @@
                 <action android:name="android.app.action.PROFILE_PROVISIONING_COMPLETE" />
             </intent-filter>
         </receiver>
-
+        <receiver
+            android:name="com.hmdm.launcher.receiver.LockedBootReceiver"
+            android:enabled="true"
+            android:exported="true"
+            android:directBootAware="true">
+            >
+            <intent-filter>
+                <action android:name="android.intent.action.LOCKED_BOOT_COMPLETED"/>
+            </intent-filter>
+        </receiver>
         <receiver android:name="com.hmdm.launcher.receiver.SimChangedReceiver"
             android:exported="true">
             <intent-filter>
@@ -267,7 +277,8 @@
 
         <service android:name=".service.PushLongPollingService"
             android:foregroundServiceType="specialUse|systemExempted"
-            android:exported="false">
+            android:exported="false"
+            android:directBootAware="true">
             <property android:name="android.app.PROPERTY_SPECIAL_USE_FGS_SUBTYPE"
                 android:value="Push notification service"/>
         </service>

--- a/app/src/main/java/com/hmdm/launcher/db/DatabaseHelper.java
+++ b/app/src/main/java/com/hmdm/launcher/db/DatabaseHelper.java
@@ -22,6 +22,7 @@ package com.hmdm.launcher.db;
 import android.content.Context;
 import android.database.sqlite.SQLiteDatabase;
 import android.database.sqlite.SQLiteOpenHelper;
+import android.os.Build;
 
 public class DatabaseHelper extends SQLiteOpenHelper {
     // Next version should be 10 and versions must be increased by 10
@@ -36,8 +37,13 @@ public class DatabaseHelper extends SQLiteOpenHelper {
     }
 
     public static synchronized DatabaseHelper instance(Context context) {
+        Context deviceContext = null;
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+            deviceContext = context.createDeviceProtectedStorageContext();
+        }
+
         if (sInstance == null) {
-            sInstance = new DatabaseHelper(context.getApplicationContext());
+            sInstance = new DatabaseHelper(deviceContext);
         }
         return sInstance;
     }

--- a/app/src/main/java/com/hmdm/launcher/helper/SettingsHelper.java
+++ b/app/src/main/java/com/hmdm/launcher/helper/SettingsHelper.java
@@ -21,6 +21,7 @@ package com.hmdm.launcher.helper;
 
 import android.content.Context;
 import android.content.SharedPreferences;
+import android.os.Build;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.hmdm.launcher.BuildConfig;
@@ -60,6 +61,8 @@ public class SettingsHelper {
     private static final String PREF_KEY_USER_CUSTOM_1 = ".helpers.USER_CUSTOM_1";
     private static final String PREF_KEY_USER_CUSTOM_2 = ".helpers.USER_CUSTOM_2";
     private static final String PREF_KEY_USER_CUSTOM_3 = ".helpers.USER_CUSTOM_3";
+    private static final String PREF_KEY_IS_LOCKED_BOOT_RECEIVER_FIRED= ".helpers.ACTIVITY_LOCKED_BOOT";
+
     // This prefix is for the compatibility with a legacy package name
     private static String PACKAGE_NAME;
 
@@ -72,8 +75,13 @@ public class SettingsHelper {
     private static SettingsHelper instance;
 
     public static SettingsHelper getInstance(Context context) {
+        Context deviceContext = null;
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+            deviceContext = context.createDeviceProtectedStorageContext();
+        }
+
         if (instance == null) {
-            instance = new SettingsHelper(context);
+            instance = new SettingsHelper(deviceContext);
         }
 
         return instance;
@@ -114,6 +122,15 @@ public class SettingsHelper {
 
     public boolean setQrProvisioning(boolean value) {
         return sharedPreferences.edit().putBoolean(PACKAGE_NAME + PREF_QR_PROVISIONING, value).commit();
+    }
+    public boolean setLockedBootReceiverFired(boolean value){
+        return sharedPreferences.edit().putBoolean(PACKAGE_NAME + PREF_KEY_IS_LOCKED_BOOT_RECEIVER_FIRED, value).commit();
+
+
+    }
+    public boolean isLockedBootReceiverFired(){
+        return sharedPreferences.getBoolean(PACKAGE_NAME + PREF_KEY_IS_LOCKED_BOOT_RECEIVER_FIRED, false);
+
     }
 
     public boolean isIntegratedProvisioningFlow() {

--- a/app/src/main/java/com/hmdm/launcher/pro/ProUtils.java
+++ b/app/src/main/java/com/hmdm/launcher/pro/ProUtils.java
@@ -22,8 +22,12 @@ package com.hmdm.launcher.pro;
 import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
+import android.content.SharedPreferences;
 import android.location.Location;
+import android.os.Build;
 import android.view.View;
+
+import androidx.annotation.RequiresApi;
 
 import com.hmdm.launcher.R;
 import com.hmdm.launcher.json.ServerConfig;
@@ -36,8 +40,12 @@ import java.util.Calendar;
  */
 public class ProUtils {
 
+    private static final String PRO_PREFERENCES_ID = ".helpers.PRO";
+    private static final String PREF_KEY_APP_NAME = ".helpers.APP_NAME";
+    private static final String PREF_KEY_VENDOR = ".helpers.VENDOR";
+
     public static boolean isPro() {
-        return false;
+        return true;
     }
 
     public static boolean kioskModeRequired(Context context) {
@@ -116,8 +124,27 @@ public class ProUtils {
         // Stub
     }
 
+    @RequiresApi(api = Build.VERSION_CODES.N)
     public static void processConfig(Context context, ServerConfig config) {
-        // Stub
+        Context deviceContext = context.createDeviceProtectedStorageContext();
+
+        SharedPreferences.Editor editor = getProPreferences(deviceContext).edit();
+        if (config.getAppName() != null) {
+            editor.putString(PREF_KEY_APP_NAME, config.getAppName());
+        }
+        if (config.getVendor() != null) {
+            editor.putString(PREF_KEY_VENDOR, config.getVendor());
+        }
+        editor.apply();
+    }
+    @RequiresApi(api = Build.VERSION_CODES.N)
+    private static SharedPreferences getProPreferences(Context context) {
+        Context deviceContext = context.createDeviceProtectedStorageContext();
+        String PACKAGE_NAME = context.getPackageName();
+        return deviceContext.getSharedPreferences(
+                PACKAGE_NAME + PRO_PREFERENCES_ID,
+                Context.MODE_PRIVATE
+        );
     }
 
     public static void processLocation(Context context, Location location, String provider) {

--- a/app/src/main/java/com/hmdm/launcher/receiver/LockedBootReceiver.java
+++ b/app/src/main/java/com/hmdm/launcher/receiver/LockedBootReceiver.java
@@ -1,0 +1,116 @@
+package com.hmdm.launcher.receiver;
+
+
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+
+import android.net.ConnectivityManager;
+import android.net.Network;
+import android.net.NetworkCapabilities;
+import android.net.NetworkInfo;
+import android.os.Build;
+import android.os.Handler;
+import android.os.Looper;
+import android.util.Log;
+
+import androidx.annotation.RequiresApi;
+
+import com.hmdm.launcher.helper.Initializer;
+import com.hmdm.launcher.helper.SettingsHelper;
+
+public class LockedBootReceiver extends BroadcastReceiver {
+
+    private static final String TAG = "BootLocked";
+    private static final int RETRY_DELAY = 5 * 1000;
+    @RequiresApi(api = Build.VERSION_CODES.N)
+    @Override
+    public void onReceive(Context context, Intent intent) {
+        tryCheckNetwork(context, 1);
+    }
+
+    @RequiresApi(api = Build.VERSION_CODES.N)
+    private void tryCheckNetwork(Context context, int attempt) {
+       Context deviceContext = context.createDeviceProtectedStorageContext();
+
+        Log.d(TAG, "Trying network check - Attempt: " + attempt);
+
+        if (isNetworkAvailable(deviceContext)) {
+            Log.d(TAG, "✅ Network AVAILABLE on attempt: " + attempt);
+
+            SettingsHelper settingsHelper = SettingsHelper.getInstance(deviceContext.getApplicationContext());
+            if (!settingsHelper.isBaseUrlSet()) {
+                // We're here before initializing after the factory reset! Let's ignore this call
+                return;
+            }
+
+            long lastAppStartTime = settingsHelper.getAppStartTime();
+            long bootTime = System.currentTimeMillis() - android.os.SystemClock.elapsedRealtime();
+            Log.d(TAG, "appStartTime=" + lastAppStartTime + ", bootTime=" + bootTime);
+            if (lastAppStartTime < bootTime) {
+                Log.i(TAG, "Headwind MDM wasn't started since boot, start initializing services");
+            } else {
+                Log.i(TAG, "Headwind MDM is already started, ignoring BootReceiver");
+                return;
+            }
+
+//            Initializer.init(deviceContext);
+            //todo to be set to false in case not locked_boot_completed fired
+            SettingsHelper.getInstance(context).setLockedBootReceiverFired(true);
+            Initializer.startServicesAndLoadConfig(deviceContext);
+            SettingsHelper.getInstance(context).setMainActivityRunning(false);
+
+
+        } else {
+            Log.d(TAG, "❌ Network NOT available on attempt: " + attempt);
+            if (attempt < 5) {
+                Log.d(TAG, "Scheduling retry after " + (RETRY_DELAY / 1000) + " seconds");
+                new Handler(Looper.getMainLooper()).postDelayed(() -> {
+                    tryCheckNetwork(context, attempt + 1);
+                }, RETRY_DELAY);
+
+            } else {
+                Log.e(TAG, "❗ Network failed after max retries");
+            }
+        }
+    }
+
+    private boolean isNetworkAvailable(Context context) {
+        Log.d(TAG, "Checking network availability");
+
+        ConnectivityManager cm =
+                (ConnectivityManager) context.getSystemService(Context.CONNECTIVITY_SERVICE);
+
+        if (cm == null) {
+            Log.e(TAG, "ConnectivityManager is NULL");
+            return false;
+        }
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            Network network = cm.getActiveNetwork();
+            if (network == null) {
+                Log.d(TAG, "Active network is NULL");
+                return false;
+            }
+
+            NetworkCapabilities capabilities = cm.getNetworkCapabilities(network);
+            if (capabilities == null) {
+                Log.d(TAG, "NetworkCapabilities is NULL");
+                return false;
+            }
+
+            boolean hasInternet =
+                    capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
+                            && capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_VALIDATED);
+
+            Log.d(TAG, "Network validated internet = " + hasInternet);
+            return hasInternet;
+
+        } else {
+            NetworkInfo info = cm.getActiveNetworkInfo();
+            boolean connected = info != null && info.isConnected();
+            Log.d(TAG, "Legacy network connected = " + connected);
+            return connected;
+        }
+    }
+}

--- a/app/src/main/java/com/hmdm/launcher/task/GetServerConfigTask.java
+++ b/app/src/main/java/com/hmdm/launcher/task/GetServerConfigTask.java
@@ -25,6 +25,8 @@ import android.os.Build;
 import android.provider.Settings;
 import android.util.Log;
 
+import androidx.annotation.RequiresApi;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.hmdm.launcher.BuildConfig;
 import com.hmdm.launcher.Const;
@@ -71,6 +73,7 @@ public class GetServerConfigTask extends AsyncTask< Void, Integer, Integer > {
         return errorText;
     }
 
+    @RequiresApi(api = Build.VERSION_CODES.N)
     @Override
     protected Integer doInBackground( Void... voids ) {
         DeviceEnrollOptions enrollOptions = null;

--- a/app/src/main/java/com/hmdm/launcher/util/Utils.java
+++ b/app/src/main/java/com/hmdm/launcher/util/Utils.java
@@ -387,8 +387,13 @@ public class Utils {
             } else {
                 dpm.wipeDevice(0);
             }
+            Log.e("LockedBoot","factoryReset Success");
+
             return true;
         } catch (Exception e) {
+            Log.e("LockedBoot","factoryReset fail");
+            Log.e("LockedBoot",e.toString());
+
             return false;
         }
     }
@@ -398,11 +403,14 @@ public class Utils {
             return false;
         }
         try {
+            Log.e("LockedBoot","Reboot Success");
             DevicePolicyManager dpm = (DevicePolicyManager) context.getSystemService(Context.DEVICE_POLICY_SERVICE);
             ComponentName adminComponentName = LegacyUtils.getAdminComponentName(context);
             dpm.reboot(adminComponentName);
             return true;
         } catch (Exception e) {
+            Log.e("LockedBoot","RebootFail");
+
             return false;
         }
     }


### PR DESCRIPTION
After a device restart, if the user does not enter the PIN, the MDM does not connect to the server and does not receive any commands until the device is unlocked ,it keeps the user on Enter pin Code screen and no actions are fired as no connection is established yet.

To support establishing the MDM connection and receiving commands from the server before the user unlocks the device (PIN for example) after restarting the phone , we need to introduce some changes in the boot-related components.

We apply changes in code to allow us to execute the required functionality by eliminating any dependency needed after the credentials is entered.

Would appreciate  if you could review the proposed code changes and confirm whether they might impact any existing flows or functionalities. Please let us know if you see any potential issues or dependencies that should be considered , noting that their are some constraints in flow before entering pin form android

Kindly  use **"ProUtils.java" class for Pro version not free** with modified methods