### PR TITLE
 PR: Fix "Run after install" not launching apps when config updates in background

### DIFF
--- a/app/src/main/java/com/hmdm/launcher/helper/ConfigUpdater.java
+++ b/app/src/main/java/com/hmdm/launcher/helper/ConfigUpdater.java
@@ -1076,6 +1076,27 @@ public class ConfigUpdater {
                                             }
                                         }
                                     }
+                                    // Launch app immediately only for background updates.
+                                    // In foreground updates, MainActivity handles delayed autorun via applicationsForRun.
+                                    ServerConfig config = settingsHelper.getConfig();
+                                    if (uiNotifier == null && config != null && config.getApplications() != null) {
+                                        for (Application app : config.getApplications()) {
+                                            if (app.getPkg() != null && app.getPkg().equals(packageName) && app.isRunAfterInstall()) {
+                                                Intent launchIntent = context.getPackageManager().getLaunchIntentForPackage(packageName);
+                                                if (launchIntent != null) {
+                                                    launchIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_RESET_TASK_IF_NEEDED);
+                                                    try {
+                                                        context.startActivity(launchIntent);
+                                                        RemoteLogger.log(context, Const.LOG_INFO, "Launched app after install: " + packageName);
+                                                    } catch (Exception e) {
+                                                        RemoteLogger.log(context, Const.LOG_WARN, "Failed to launch app after install: " + e.getMessage());
+                                                        e.printStackTrace();
+                                                    }
+                                                }
+                                                break;
+                                            }
+                                        }
+                                    }
                                     if (uiNotifier != null) {
                                         uiNotifier.onAppInstallComplete(packageName);
                                     }


### PR DESCRIPTION
# PR: Fix "Run after install" not launching apps when config updates in background

**Repository:** [h-mdm/hmdm-android](https://github.com/h-mdm/hmdm-android)  
**Target:** `master`  
**Related:** Headwind MDM launcher

---

## Problem

The "Run after install" application setting does not reliably launch apps after installation. Apps configured with this option often fail to start automatically; administrators must manually send a `runApp` push notification to launch them.

### Root cause

1. **Background config updates**: When the config is updated while MainActivity is not in the foreground (e.g. `configUpdated` push, scheduled poll, or app install completion), `ConfigUpdater.notifyConfigUpdate()` creates a new `ConfigUpdater` with `uiNotifier = null`. That instance populates `applicationsForRun` for run-after-install apps, but `onConfigUpdateComplete()` is never called, so `scheduleInstalledAppsRun()` never runs.

2. **Timing**: The existing flow adds apps to `applicationsForRun` in the download AsyncTask's `onPostExecute`—before the PackageInstaller has actually completed. When `showContent()` runs, it may execute before the app is installed.

### Why manual `runApp` push works

The push notification triggers `PushNotificationProcessor.runApplication()` directly, which launches the app regardless of MainActivity state.

---

## Solution

Launch run-after-install apps **in the install completion BroadcastReceiver** when `STATUS_SUCCESS` is received, **only for background updates** (`uiNotifier == null`). This ensures:

- The app is actually installed before we try to launch it
- It works when MainActivity is not in the foreground (the broken case)
- Foreground flow remains unchanged (`applicationsForRun` + `scheduleInstalledAppsRun()`)

---

## Patch

**File:** `app/src/main/java/com/hmdm/launcher/helper/ConfigUpdater.java`

In `registerAppInstallReceiver()`, inside the `case PackageInstaller.STATUS_SUCCESS:` block, add the run-after-install launch logic after permission granting and before `uiNotifier.onAppInstallComplete()`:

```diff
         case PackageInstaller.STATUS_SUCCESS:
             String packageName = intent.getStringExtra(Const.PACKAGE_NAME);
             if (packageName != null) {
                 RemoteLogger.log(context, Const.LOG_DEBUG, "App " + packageName + " installed successfully");
                 Log.i(Const.LOG_TAG, "Install complete: " + packageName);
                 File file = pendingInstallations.get(packageName);
                 if (file != null) {
                     pendingInstallations.remove(packageName);
                     InstallUtils.deleteTempApk(file);
                 }
                 if (BuildConfig.SYSTEM_PRIVILEGES || Utils.isDeviceOwner(context)) {
                     // Always grant all dangerous rights to the app
                     Utils.autoGrantRequestedPermissions(context, packageName,
                         appPermissionStrategy, false);
                     if (BuildConfig.SYSTEM_PRIVILEGES && packageName.equals(Const.APUPPET_PACKAGE_NAME)) {
                         // Automatically grant required permissions to aPuppet if we can
                         // Note: device owner can only grant permissions to self, not to other apps!
                         try {
                             SystemUtils.autoSetAccessibilityPermission(context,
                                 Const.APUPPET_PACKAGE_NAME, Const.APUPPET_SERVICE_CLASS_NAME);
                             SystemUtils.autoSetOverlayPermission(context,
                                 Const.APUPPET_PACKAGE_NAME);
                         } catch (Exception e) {
                             e.printStackTrace();
                         }
                     }
                 }
+                // Launch app immediately only for background updates.
+                // In foreground updates, MainActivity handles delayed autorun via applicationsForRun.
+                ServerConfig config = settingsHelper.getConfig();
+                if (uiNotifier == null && config != null && config.getApplications() != null) {
+                    for (Application app : config.getApplications()) {
+                        if (app.getPkg() != null && app.getPkg().equals(packageName) && app.isRunAfterInstall()) {
+                            Intent launchIntent = context.getPackageManager().getLaunchIntentForPackage(packageName);
+                            if (launchIntent != null) {
+                                launchIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_RESET_TASK_IF_NEEDED);
+                                try {
+                                    context.startActivity(launchIntent);
+                                    RemoteLogger.log(context, Const.LOG_INFO, "Launched app after install: " + packageName);
+                                } catch (Exception e) {
+                                    RemoteLogger.log(context, Const.LOG_WARN, "Failed to launch app after install: " + e.getMessage());
+                                    e.printStackTrace();
+                                }
+                            }
+                            break;
+                        }
+                    }
+                }
                 if (uiNotifier != null) {
                     uiNotifier.onAppInstallComplete(packageName);
                 }
             } else {
```

---

## Behavior after fix

| Scenario | Before | After |
|----------|--------|-------|
| Config update with MainActivity in foreground | Existing delayed autorun flow | Existing delayed autorun flow (unchanged) |
| Config update in background (push/poll) | Never worked | Works |
| Multiple apps with run-after-install (background updates) | Unreliable | Each launches when its install completes |

---

## Testing

1. Configure an app with "Run after install" in the Headwind MDM web panel.
2. Assign the app to a configuration and push to a device.
3. **Test A**: With Headwind launcher in foreground — verify existing delayed autorun behavior is unchanged (no regression).
4. **Test B**: Keep launcher in background (another app in foreground), trigger install via config update — app should launch after install.
5. **Test C**: Send `configUpdated` push while launcher is in background, then install the app — app should launch when install completes.

---

## Note on `applicationsForRun` and `scheduleInstalledAppsRun()`

The existing `applicationsForRun` + `scheduleInstalledAppsRun()` flow remains the foreground path.  
The new BroadcastReceiver launch path is intentionally limited to background updates (`uiNotifier == null`) to avoid duplicate launches when UI-driven scheduling is active.

---

## Checklist

- [x] Fix addresses the root cause (background updates, timing)
- [x] No new dependencies
- [x] Uses existing config and Application model
- [x] Logging for debugging
- [x] Exception handling for startActivity failures
